### PR TITLE
Revert "Migrated to .NET Framework 4.8 #9"

### DIFF
--- a/ExperimentalProbability.Calculations/ExperimentalProbability.Calculations.csproj
+++ b/ExperimentalProbability.Calculations/ExperimentalProbability.Calculations.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/ExperimentalProbability.UI/ExperimentalProbability.UI.csproj
+++ b/ExperimentalProbability.UI/ExperimentalProbability.UI.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <StartupObject>ExperimentalProbability.UI.App</StartupObject>
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
Upon even further research I decided to rollback to .NET 6.0. Because no new user friendly features were introduced and I was fooled by a description on the internet. 